### PR TITLE
Use `.to_s` instead of `.message` to get exception info, since an edge

### DIFF
--- a/lib/simple_health_check/base.rb
+++ b/lib/simple_health_check/base.rb
@@ -1,5 +1,6 @@
 module SimpleHealthCheck
   class Base
+    attr_reader :service_name
     # derive a check class from this and add your checks.  the passed in response object
     # can set the key (name) and value (status) of the check to run.
     # All the combined checks are returned in a single hash.  Ensure you catch
@@ -38,7 +39,7 @@ module SimpleHealthCheck
           response.status_code = rv
         rescue
           # catch exceptions since we don't want the health-check to bubble all the way to the top
-          response.add name: "#{@service_name}_connection_error", status: $ERROR_INFO.message
+          response.add name: "#{@service_name}_connection_error", status: $ERROR_INFO.to_s
           response.status_code = :internal_server_error
           response
         end

--- a/lib/simple_health_check/http_endpoint_check.rb
+++ b/lib/simple_health_check/http_endpoint_check.rb
@@ -12,7 +12,7 @@ class SimpleHealthCheck::HttpEndpointCheck < SimpleHealthCheck::Base
         response.add name: @service_name, status: rv
         response.status_code = :ok
       rescue
-        response.add name: "#{@service_name}_connection_error", status: $ERROR_INFO.message
+        response.add name: "#{@service_name}_connection_error", status: $ERROR_INFO.to_s
       end
     else
       response.add name: @service_name, status: 'missing_configuration'

--- a/lib/simple_health_check/mysql_check.rb
+++ b/lib/simple_health_check/mysql_check.rb
@@ -16,7 +16,7 @@ class SimpleHealthCheck::MysqlCheck < SimpleHealthCheck::Base
         response.status_code = rv
       rescue
         # catch exceptions since we don't want the health-check to bubble all the way to the otp
-        response.add name: "#{@service_name}_connection_error", status: $ERROR_INFO.message
+        response.add name: "#{@service_name}_connection_error", status: $ERROR_INFO.to_s
         response.status_code = :internal_server_error
       end
     else
@@ -28,7 +28,7 @@ class SimpleHealthCheck::MysqlCheck < SimpleHealthCheck::Base
         response.status_code = :ok
       rescue
         response.add name: @service_name, status: :internal_server_error
-        response.add name: "#{@service_name}_error", status: $ERROR_INFO.message
+        response.add name: "#{@service_name}_error", status: $ERROR_INFO.to_s
         response.status_code = :internal_server_error
       end
     end


### PR DESCRIPTION
case might occur where the exception object turns out to be nil.

Wrap each check in the `run_checks` method to avoid an exception at the
loop level from stopping all health checks.